### PR TITLE
Let assertEquals be strict assertSame

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,4 +32,4 @@ jobs:
         run: composer install
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit

--- a/tests/Linna/Http/Message/ResponseTest.php
+++ b/tests/Linna/Http/Message/ResponseTest.php
@@ -141,8 +141,8 @@ class ResponseTest extends TestCase
     {
         $response = new Response($code);
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals($code, $response->getStatusCode());
-        $this->assertEquals($reasonPhrase, $response->getReasonPhrase());
+        $this->assertSame($code, $response->getStatusCode());
+        $this->assertSame($reasonPhrase, $response->getReasonPhrase());
     }
 
     /**
@@ -169,8 +169,8 @@ class ResponseTest extends TestCase
 
         $this->assertNotEquals($response->getStatusCode(), self::$response->getStatusCode());
         $this->assertNotEquals($response->getReasonPhrase(), self::$response->getReasonPhrase());
-        $this->assertEquals(Response::STATUS_FORBIDDEN, $response->getStatusCode());
-        $this->assertEquals('Forbidden', $response->getReasonPhrase());
+        $this->assertSame(Response::STATUS_FORBIDDEN, $response->getStatusCode());
+        $this->assertSame('Forbidden', $response->getReasonPhrase());
     }
 
     /**

--- a/tests/Linna/Http/Message/StreamTest.php
+++ b/tests/Linna/Http/Message/StreamTest.php
@@ -169,7 +169,7 @@ class StreamTest extends TestCase
 
         $stream->write('abcdefghijklmnopqrstuwxyz');
 
-        $this->assertEquals(25, $stream->getSize());
+        $this->assertSame(25, $stream->getSize());
 
         $stream->close();
     }
@@ -187,7 +187,7 @@ class StreamTest extends TestCase
         $stream->write('abcdefghijklmnopqrstuwxyz');
         $stream->close();
 
-        $this->assertEquals(0, $stream->getSize());
+        $this->assertSame(0, $stream->getSize());
     }
 
     /**
@@ -204,13 +204,13 @@ class StreamTest extends TestCase
         $stream->write('abcdefghijklmnopqrstuwxyz');
         $stream->rewind();
 
-        $this->assertEquals(0, $stream->tell());
+        $this->assertSame(0, $stream->tell());
 
         $stream->seek(2);
-        $this->assertEquals(2, $stream->tell());
+        $this->assertSame(2, $stream->tell());
 
         $stream->rewind();
-        $this->assertEquals(0, $stream->tell());
+        $this->assertSame(0, $stream->tell());
 
         $stream->close();
     }
@@ -248,17 +248,17 @@ class StreamTest extends TestCase
         $stream->rewind();
 
         //not at the end of the file
-        $this->assertEquals(0, $stream->tell());
+        $this->assertSame(0, $stream->tell());
         $this->assertFalse($stream->eof());
 
         //not at the end of the file
         $stream->read(25);
-        $this->assertEquals(25, $stream->tell());
+        $this->assertSame(25, $stream->tell());
         $this->assertFalse($stream->eof());
 
         //at the end of the file
         $stream->read(1);
-        $this->assertEquals(25, $stream->tell());
+        $this->assertSame(25, $stream->tell());
         $this->assertTrue($stream->eof());
 
         //true with stream closed
@@ -310,16 +310,16 @@ class StreamTest extends TestCase
 
         $stream->write('abcdefghijklmnopqrstuwxyz');
 
-        $this->assertEquals(25, $stream->tell());
+        $this->assertSame(25, $stream->tell());
 
         $stream->rewind();
-        $this->assertEquals(0, $stream->tell());
+        $this->assertSame(0, $stream->tell());
 
         $stream->read(25);
-        $this->assertEquals(25, $stream->tell());
+        $this->assertSame(25, $stream->tell());
 
         $stream->rewind();
-        $this->assertEquals(0, $stream->tell());
+        $this->assertSame(0, $stream->tell());
     }
 
     /**
@@ -389,7 +389,7 @@ class StreamTest extends TestCase
 
         $stream = new Stream(\fopen($file, $mode));
 
-        $this->assertEquals($result, $stream->isWritable());
+        $this->assertSame($result, $stream->isWritable());
     }
 
     /**
@@ -421,7 +421,7 @@ class StreamTest extends TestCase
         $stream->write('abcdefghijklmnopqrstuwxyz');
         $stream->rewind();
 
-        $this->assertEquals('abcdefghijklmnopqrstuwxyz', $stream->read(25));
+        $this->assertSame('abcdefghijklmnopqrstuwxyz', $stream->read(25));
     }
 
     /**
@@ -512,7 +512,7 @@ class StreamTest extends TestCase
 
         $stream = new Stream(\fopen($file, $mode));
 
-        $this->assertEquals($result, $stream->isReadable());
+        $this->assertSame($result, $stream->isReadable());
     }
 
     /**
@@ -529,7 +529,7 @@ class StreamTest extends TestCase
         $stream->write('abcdefghijklmnopqrstuwxyz');
         $stream->rewind();
 
-        $this->assertEquals('abcdefghijklmnopqrstuwxyz', $stream->read(25));
+        $this->assertSame('abcdefghijklmnopqrstuwxyz', $stream->read(25));
     }
 
     /**
@@ -582,8 +582,8 @@ class StreamTest extends TestCase
         $stream->write('abcdefghijklmnopqrstuwxyz');
         $stream->rewind();
 
-        $this->assertEquals('abcdefghijklmnopqrst', $stream->read(20));
-        $this->assertEquals('uwxyz', $stream->getContents());
+        $this->assertSame('abcdefghijklmnopqrst', $stream->read(20));
+        $this->assertSame('uwxyz', $stream->getContents());
     }
 
     /**

--- a/tests/Linna/Http/Message/UriTest.php
+++ b/tests/Linna/Http/Message/UriTest.php
@@ -36,14 +36,14 @@ class UriTest extends TestCase
         $uri = new Uri(self::$uri);
 
         $this->assertInstanceOf(Uri::class, $uri);
-        $this->assertEquals('http', $uri->getScheme());
-        $this->assertEquals('username:password', $uri->getUserInfo());
-        $this->assertEquals('hostname.com', $uri->getHost());
-        $this->assertEquals(9090, $uri->getPort());
-        $this->assertEquals('username:password@hostname.com:9090', $uri->getAuthority());
-        $this->assertEquals('/path', $uri->getPath());
-        $this->assertEquals('arg=value', $uri->getQuery());
-        $this->assertEquals('anchor', $uri->getFragment());
+        $this->assertSame('http', $uri->getScheme());
+        $this->assertSame('username:password', $uri->getUserInfo());
+        $this->assertSame('hostname.com', $uri->getHost());
+        $this->assertSame(9090, $uri->getPort());
+        $this->assertSame('username:password@hostname.com:9090', $uri->getAuthority());
+        $this->assertSame('/path', $uri->getPath());
+        $this->assertSame('arg=value', $uri->getQuery());
+        $this->assertSame('anchor', $uri->getFragment());
     }
 
     /**
@@ -118,7 +118,7 @@ class UriTest extends TestCase
      */
     public function testGetAuthority(string $autority, string $expected): void
     {
-        $this->assertEquals($expected, (new Uri("{$autority}/path?arg=value#anchor"))->getAuthority());
+        $this->assertSame($expected, (new Uri("{$autority}/path?arg=value#anchor"))->getAuthority());
     }
 
     /**
@@ -146,7 +146,7 @@ class UriTest extends TestCase
      */
     public function testGetPort(string $scheme, string $port, int $expected): void
     {
-        $this->assertEquals($expected, (new Uri("{$scheme}://username:password@hostname.com{$port}/path?arg=value#anchor"))->getPort());
+        $this->assertSame($expected, (int)(new Uri("{$scheme}://username:password@hostname.com{$port}/path?arg=value#anchor"))->getPort());
     }
 
     /**
@@ -158,7 +158,7 @@ class UriTest extends TestCase
     {
         $uri = (new Uri(self::$uri))->withScheme('https');
 
-        $this->assertEquals('https', $uri->getScheme());
+        $this->assertSame('https', $uri->getScheme());
     }
 
     /**
@@ -196,7 +196,7 @@ class UriTest extends TestCase
     {
         $uri = (new Uri(self::$uri))->withUserInfo('testUser', 'password');
 
-        $this->assertEquals('testUser:password', $uri->getUserInfo());
+        $this->assertSame('testUser:password', $uri->getUserInfo());
     }
 
     /**
@@ -208,7 +208,7 @@ class UriTest extends TestCase
     {
         $uri = (new Uri(self::$uri))->withUserInfo('testUser');
 
-        $this->assertEquals('testUser', $uri->getUserInfo());
+        $this->assertSame('testUser', $uri->getUserInfo());
     }
 
     /**
@@ -220,7 +220,7 @@ class UriTest extends TestCase
     {
         $uri = (new Uri(self::$uri))->withUserInfo('');
 
-        $this->assertEquals('', $uri->getUserInfo());
+        $this->assertSame('', $uri->getUserInfo());
     }
 
     /**
@@ -232,7 +232,7 @@ class UriTest extends TestCase
     {
         $uri = (new Uri(self::$uri))->withHost('example.com');
 
-        $this->assertEquals('example.com', $uri->getHost());
+        $this->assertSame('example.com', $uri->getHost());
     }
 
     /**
@@ -270,7 +270,7 @@ class UriTest extends TestCase
     {
         $uri = (new Uri(self::$uri))->withPort(8080);
 
-        $this->assertEquals(8080, $uri->getPort());
+        $this->assertSame(8080, $uri->getPort());
     }
 
     /**
@@ -356,8 +356,8 @@ class UriTest extends TestCase
     {
         $uri = (new Uri(self::$uri))->withPath('/otherpath');
 
-        $this->assertEquals('/otherpath', $uri->getPath());
-        $this->assertEquals('http://username:password@hostname.com:9090/otherpath?arg=value#anchor', (string) $uri);
+        $this->assertSame('/otherpath', $uri->getPath());
+        $this->assertSame('http://username:password@hostname.com:9090/otherpath?arg=value#anchor', (string) $uri);
     }
 
     /**
@@ -432,7 +432,7 @@ class UriTest extends TestCase
      */
     public function testUriToString(string $testUri): void
     {
-        $this->assertEquals($testUri, (string) (new Uri($testUri)));
+        $this->assertSame($testUri, (string) (new Uri($testUri)));
     }
 
     /**
@@ -464,8 +464,8 @@ class UriTest extends TestCase
     {
         $uri = (new Uri(self::$uri))->withQuery($withQuery);
 
-        $this->assertEquals($expectedQuery, $uri->getQuery());
-        $this->assertEquals($expectedUri, (string) $uri);
+        $this->assertSame($expectedQuery, $uri->getQuery());
+        $this->assertSame($expectedUri, (string) $uri);
     }
 
     /**
@@ -523,8 +523,8 @@ class UriTest extends TestCase
     {
         $uri = (new Uri(self::$uri))->withFragment($withFragment);
 
-        $this->assertEquals($expectedFragment, $uri->getFragment());
-        $this->assertEquals($expectedUri, (string) $uri);
+        $this->assertSame($expectedFragment, $uri->getFragment());
+        $this->assertSame($expectedUri, (string) $uri);
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Let `assetEquals` be strict `assertSame`.
- According the [PHPUnit changedlog](https://github.com/sebastianbergmann/phpunit/blob/main/ChangeLog-10.0.md#1000---2023-02-03), it should remove the `--verbose` option.